### PR TITLE
Remove deprecated 'queries' param from REST mode

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -174,7 +174,7 @@ class PineconeRest(FastHttpUser):
         super().__init__(environment)
 
     def query(self, name: str, q_vector: list, top_k: int, q_filter=None, namespace=None):
-        json = {"queries": [{"values": q_vector}],
+        json = {"vector": q_vector,
                 "topK": top_k,
                 "includeMetadata": includeMetadataValue,
                 "includeValues": includeValuesValue}

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -1,6 +1,8 @@
+import json
 import os
 import pytest
 import subprocess
+import sys
 from subprocess import PIPE
 
 
@@ -8,59 +10,55 @@ from subprocess import PIPE
 def index_host():
     host = os.environ.get('INDEX_HOST', None)
     if host is None or host == '':
-        raise Exception('INDEX_HOST environment variable is not set')
+        raise Exception(
+            'INDEX_HOST environment variable is not set. Set to the host of a Pinecone index suitable for testing '
+            'against.')
     return host
 
 
 def spawn_locust(host, mode, extra_args):
-    return subprocess.Popen(
-        ["locust", "--host", host, "--iterations=1", "--headless", "--pinecone-mode",
+    proc = subprocess.Popen(
+        ["locust", "--host", host, "--iterations=1", "--headless", "--json", "--pinecone-mode",
          mode] + extra_args,
         stdout=PIPE,
         stderr=PIPE,
         text=True,
     )
+    stdout, stderr = proc.communicate(timeout=4)
+    # Echo locust's stdout & stderr to our own, so pytest can capture and
+    # report them on error.
+    print(stdout)
+    print(stderr, file=sys.stderr)
+    return proc, stdout, stderr
 
 
 @pytest.mark.parametrize("mode", ["rest", "sdk", "sdk+grpc"])
 class TestPinecone:
+    @staticmethod
+    def do_request(index_host, mode, tag, expected_name):
+        (proc, stdout, stderr) = spawn_locust(index_host, mode, ["--tags", tag])
+        # Check that stderr contains the expected output, and no errors.
+        assert '"Traceback' not in stderr
+        assert 'All users spawned: {"PineconeUser": 1}' in stderr
+        # Check stats output shows expected requests occurred and they
+        # succeeded.
+        stats = json.loads(stdout)[0]
+        assert expected_name in stats['name']
+        assert stats['num_requests'] == 1
+        assert stats['num_failures'] == 0
+        assert proc.returncode == 0
 
     def test_pinecone_query(self, index_host, mode):
-        proc = spawn_locust(index_host, mode, ["--tags=query"])
-        stdout, stderr = proc.communicate(timeout=4)
-        print("STDOUT:", stdout)
-        print("STDERR:", stderr)
-        assert "Traceback" not in stderr
-        assert 'All users spawned: {"PineconeUser": 1}' in stderr
-        assert 'Vector (Query only)' in stderr
-        assert proc.returncode == 0
+        self.do_request(index_host, mode, 'query', 'Vector (Query only)')
 
     def test_pinecone_query_meta(self, index_host, mode):
-        proc = spawn_locust(index_host, mode, ["--tags=query_meta"])
-        stdout, stderr = proc.communicate(timeout=4)
-        assert "Traceback" not in stderr
-        assert 'All users spawned: {"PineconeUser": 1}' in stderr
-        assert 'Vector + Metadata' in stderr
-        assert proc.returncode == 0
+        self.do_request(index_host, mode, 'query_meta', 'Vector + Metadata')
 
     def test_pinecone_query_namespace(self, index_host, mode):
-        proc = spawn_locust(index_host, mode, ["--tags=query_namespace"])
-        stdout, stderr = proc.communicate(timeout=4)
-        assert "Traceback" not in stderr
-        assert 'All users spawned: {"PineconeUser": 1}' in stderr
-        assert 'Vector + Namespace' in stderr
-        assert proc.returncode == 0
+        self.do_request(index_host, mode, 'query_namespace', 'Vector + Namespace')
 
     def test_pinecone_fetch(self, index_host, mode):
-        proc = spawn_locust(index_host, mode, ["--tags=fetch"])
-        stdout, stderr = proc.communicate(timeout=4)
-        assert "Traceback" not in stderr
-        assert 'Fetch' in stderr
-        assert proc.returncode == 0
+        self.do_request(index_host, mode, 'fetch', 'Fetch')
 
     def test_pinecone_delete(self, index_host, mode):
-        proc = spawn_locust(index_host, mode, ["--tags=delete"])
-        stdout, stderr = proc.communicate(timeout=4)
-        assert "Traceback" not in stderr
-        assert 'Delete' in stderr
-        assert proc.returncode == 0
+        self.do_request(index_host, mode, 'delete', 'Delete')


### PR DESCRIPTION
The 'queries' parameter to /query is deprecated, and requests using it fail with a 400 error. Remove it (and use 'vector' instead). Update integration tests to check that requests are actually successful (so issues like this can be caught by CI job).

Restructure test_requests.py to remove much of the duplication by introducing a helper method to actually run the tests.