### PR TITLE
Add option to list details of available datasets, rename =help to =list

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -78,13 +78,27 @@ class TestPinecone(TestPineconeBase):
         (proc, stdout, stderr) = spawn_locust(host="unused",
                                               mode="rest",
                                               timeout=20,
-                                              extra_args=["--pinecone-dataset=help"])
+                                              extra_args=["--pinecone-dataset=list"])
         # Check that stdout contains a list of datasets (don't want to hardcode
         # complete set as that just makes the test brittle if any new datasets are added).
         for dataset in ["ANN_MNIST_d784_euclidean                            60000      10000          784",
                         "langchain-python-docs-text-embedding-ada-002         3476          0         1536",
                         "quora_all-MiniLM-L6-bm25-100K                      100000      15000          384"]:
             assert dataset in stdout
+        assert proc.returncode == 1
+
+    def test_datasets_list_details(self):
+        # Extend timeout for listing datasets, can take longer than default 4s.
+        (proc, stdout, stderr) = spawn_locust(host="unused",
+                                              mode="rest",
+                                              timeout=20,
+                                              extra_args=["--pinecone-dataset=list-details"])
+        # Check that stdout contains at least a couple of details from the datasets (don't want to hardcode
+        # complete set as that just makes the test brittle if any new datasets are added).
+        for detail in ["gs://pinecone-datasets-dev/ANN_DEEP1B_d96_angular",
+                        "https://github.com/erikbern/ann-benchmarks",
+                        "sentence-transformers/all-MiniLM-L6-v2"]:
+            assert detail in stdout
         assert proc.returncode == 1
 
     def test_dataset_load(self, index_host):


### PR DESCRIPTION
Add a new value for --pinecone-datasets - 'list-details'. This lists
all available datasets, including all information available about
them. This is probably more detail than users would typically need,
but it can be useful for development / debugging.

Example output from a subset of the datasets:

    name                                          created_at                      documents    queries  source                                                                                                                                                      bucket                                                           task               dense_model                                                                                      sparse_model                                                            license    description    tags    args
    --------------------------------------------  ----------------------------  -----------  ---------  ----------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------------------------------------------------------  -----------------  -----------------------------------------------------------------------------------------------  ----------------------------------------------------------------------  ---------  -------------  ------  ------
    ANN_DEEP1B_d96_angular                        2023-03-10 14:17:01.481785        9990000      10000  https://github.com/erikbern/ann-benchmarks                                                                                                                  gs://pinecone-datasets-dev/ANN_DEEP1B_d96_angular                ANN                {'name': 'ANN benchmark dense model', 'tokenizer': None, 'dimension': 96}                        {'name': None, 'tokenizer': None}
    langchain-python-docs-text-embedding-ada-002  2023-06-27                           3476          0  https://huggingface.co/datasets/jamescalam/langchain-docs-23-06-27                                                                                                                                                                              {'name': 'text-embedding-ada-002', 'tokenizer': None, 'dimension': 1536}
    quora_all-MiniLM-L6-bm25-100K                 2023-06-25 10:00:00.000000         100000      15000  https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs                                                                                      gs://pinecone-datasets-dev/quora_all-MiniLM-L6-bm25              similar questions  {'name': 'sentence-transformers/msmarco-MiniLM-L6-cos-v5', 'tokenizer': None, 'dimension': 384}  {'name': 'naver/splade-cocondenser-ensembledistil', 'tokenizer': None}

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Unit tests updated to cover new functionality.
