### PR TITLE
Don't attempt to download directories of datasets

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -239,6 +239,11 @@ class Dataset:
         client = Client.create_anonymous_client()
         bucket: Bucket = client.bucket(Dataset.gcs_bucket)
         blobs = [b for b in bucket.list_blobs(prefix=self.name + "/")]
+        # Ignore directories (blobs ending in '/') as we don't explicilty need them
+        # (non-empty directories will have their files downloaded
+        # anyway).
+        blobs = [b for b in blobs if not b.name.endswith("/")]
+        logging.debug(f"Dataset consists of files:{[b.name for b in blobs]}")
 
         def should_download(blob):
             path = self.cache / blob.name


### PR DESCRIPTION

## Problem

When downloading a Dataset from GCS, skip any blobs which are just directories. This can cause issues when constructing the parent paths for actual dataset files, as if try to "download" a directory blob it is saved as a normal file and hence we cannot later create a subdirectory of the same name to contain the actual dataset files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

