### PR TITLE
Tests: Fix stdout / stderr output on subprocess.TimeoutExpired

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -29,10 +29,10 @@ def spawn_locust(host, mode, timeout, extra_args=[]):
     except subprocess.TimeoutExpired as e:
         # Echo whatever stdout / stderr we got so far, to aid in debugging
         if e.stdout:
-            for line in e.stdout.decode(errors='replace'):
+            for line in e.stdout.decode(errors='replace').splitlines():
                 print(line)
-        if e.stdout:
-            for line in e.stderr.decode(errors='replace'):
+        if e.stderr:
+            for line in e.stderr.decode(errors='replace').splitlines():
                 print(line, file=sys.stderr)
         raise
     # Echo locust's stdout & stderr to our own, so pytest can capture and


### PR DESCRIPTION
## Problem

- Fix incorrect printing of stdout / stderr in the event of a
  TimeoutExpired exception - print one line per print() statement, not
  one character per print()

- Fix incorrect predicate on printing stderr

