### PR TITLE
Remove used package 'pinecone-datasets'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ msgpack==1.0.4
 numpy==1.23.5
 pandas==2.2.0
 pinecone-client[grpc]==3.0.3
-pinecone-datasets==0.7.0
 protobuf==3.20.3
 psutil==5.9.4
 Pygments==2.15.0


### PR DESCRIPTION
## Problem

This package is now unused - dataset loading is done via pandas /
pyarrow directly.

## Solution

Remove it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Covered by existing tests
