### PR TITLE
Convert documents to correct schema when dataset has no queries

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -1,3 +1,4 @@
+import argparse
 import pathlib
 import random
 import time
@@ -55,6 +56,8 @@ def _(parser):
                             help="The dataset to use for index population and/or query generation. "
                                  "Pass the value 'list' to list available datasets, or pass 'list-details' to"
                                  " list full details of available datasets.")
+    pc_options.add_argument("--pinecone-dataset-ignore-queries", action=argparse.BooleanOptionalAction,
+                            help="Ignore and do not load the 'queries' table from the specified dataset.")
     pc_options.add_argument("--pinecone-populate-index", choices=["always", "never", "if-count-mismatch"],
                             default="if-count-mismatch",
                             help="Should the index be populated with the dataset before issuing requests. Choices: "
@@ -119,7 +122,8 @@ def setup_dataset(environment: Environment, skip_download_and_populate: bool = F
 
     logging.info(f"Loading Dataset {dataset_name} into memory for Worker...")
     environment.dataset = Dataset(dataset_name, environment.parsed_options.pinecone_dataset_cache)
-    environment.dataset.load(skip_download=skip_download_and_populate)
+    ignore_queries = environment.parsed_options.pinecone_dataset_ignore_queries
+    environment.dataset.load(skip_download=skip_download_and_populate, load_queries=not ignore_queries)
     populate = environment.parsed_options.pinecone_populate_index
     if not skip_download_and_populate and populate != "never":
         logging.info(
@@ -213,7 +217,7 @@ class Dataset:
             datasets.append(json.loads(m.download_as_string()))
         return datasets
 
-    def load(self, skip_download: bool = False):
+    def load(self, skip_download: bool = False, load_queries: bool = True):
         """
         Load the dataset, populating the 'documents' and 'queries' DataFrames.
         """
@@ -226,7 +230,8 @@ class Dataset:
 
         # If there is an explicit 'queries' dataset, then load that and use
         # for querying, otherwise use documents directly.
-        self.queries = self._load_parquet_dataset("queries")
+        if load_queries:
+            self.queries = self._load_parquet_dataset("queries")
         if self.queries.empty:
             logging.debug("Using complete documents dataset for query data")
             self.queries = self.documents

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -122,6 +122,17 @@ class TestPinecone(TestPineconeBase):
                                     "--processes", "1"])
 
 
+    def test_dataset_load_empty_queries(self, index_host):
+        # Don't load the queries set, so we test generating queries from
+        # documents.
+        test_dataset = "ANN_MNIST_d784_euclidean"
+        self.do_request(index_host, "sdk", 'query', 'Vector (Query only)',
+                        timeout=60,
+                        extra_args=["--pinecone-dataset", test_dataset,
+                                    "--pinecone-populate-index", "always",
+                                    "--pinecone-dataset-ignore-queries"])
+
+
 @pytest.mark.parametrize("mode", ["rest", "sdk", "sdk+grpc"])
 class TestPineconeModes(TestPineconeBase):
     def test_pinecone_query(self, index_host, mode):


### PR DESCRIPTION
## Problem

If a Dataset does not have an explicit 'queries' vectorset, then we simply re-use the 'documents' vectorset for queries. However, these two tables have different schemas, and attempting to use 'documents' for queries directly fails as the 'vector' field does not exist:

* Documents looks like:
   ```
    ["id", "values", "sparse_values", "metadata"]
   ```
* Queries looks like:
   ```
    ["vector", "sparse_vector", "filter", "top_k"]
   ```

## Solution

Fix by renaming 'values' to 'vector' when using documents for queries.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Add a testcase to cover this usage, which makes use of '--pinecone-dataset-ignore-queries' to skip loading the queries set and hence falls back to documents conversion.