### PR TITLE
Change default pinecone-mode from 'rest' to 'sdk+grpc'

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -59,7 +59,7 @@ def _(parser):
                             help=("Number of results to return from a Pinecone "
                                   "query() request. Defaults to 10."))
     pc_options.add_argument("--pinecone-mode", choices=["rest", "sdk", "sdk+grpc"],
-                            default="rest",
+                            default="sdk+grpc",
                             help="How to connect to the Pinecone index (default: %(default)s). Choices: "
                                  "'rest': Pinecone REST API (via a normal HTTP client). "
                                  "'sdk': Pinecone Python SDK ('pinecone-client'). "


### PR DESCRIPTION
## Problem

Connecting to a Pinecone index via the REST API is generally higher
latency than using the Python+gRPC client.

## Solution

Support for sdk+grpc has existed for a while now and seems stable (and
lower latency), change the default to sdk+grpc.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

