### PR TITLE
pyarrow.jemalloc_set_decay_ms(): Ignore if jemalloc not present

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -49,7 +49,11 @@ apikey = os.environ['PINECONE_API_KEY']
 # associated DataFrame, resulting in excessive process RSS,
 # particulary with high process counts).
 import pyarrow
-pyarrow.jemalloc_set_decay_ms(0)
+try:
+    pyarrow.jemalloc_set_decay_ms(0)
+except NotImplementedError:
+    # Raised if jemalloc is not supported by the pyarrow installation - skip
+    pass
 
 
 @events.init_command_line_parser.add_listener


### PR DESCRIPTION
## Problem

jemalloc support is not always present in pyarrow distributions - for
example pyarrow-v11 on macOS doesn't have it. Attempting to call
jemalloc_set_decay_ms() raises an exception if support is not present.

## Solution

Ignore any NotImplementedError exception raised by jemalloc_set_decay_ms().

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Tested on macOS system where pyarrow does not have jemalloc support.
