### PR TITLE
Migrate from deprecated Blob.download_as_string()

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -42,7 +42,7 @@ class Dataset:
         metadata_blobs = bucket.list_blobs(match_glob="*/metadata.json")
         datasets = []
         for m in metadata_blobs:
-            datasets.append(json.loads(m.download_as_string()))
+            datasets.append(json.loads(m.download_as_bytes()))
         return datasets
 
     def load(self, skip_download: bool = False, load_queries: bool = True,


### PR DESCRIPTION
## Problem

As per warning:

    PendingDeprecationWarning: Blob.download_as_string() is deprecated and will be removed in future. Use Blob.download_as_bytes() instead.

## Solution

Switch to Blob.download_as_bytes()

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
