### PR TITLE
Add --pinecone-throughput-per-user option

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -155,3 +155,12 @@ class TestPineconeModes(TestPineconeBase):
 
     def test_pinecone_delete(self, index_host, mode):
         self.do_request(index_host, mode, 'delete', 'Delete')
+
+    def test_pinecone_limit_throughput(self, index_host, mode):
+        self.do_request(index_host, mode, 'query', 'Vector (Query only)',
+                        extra_args=["--pinecone-throughput-per-user=1"])
+
+    def test_pinecone_unlimited_throughput(self, index_host, mode):
+        # Test that a limit of 0 meaning "unlimited" is handled correctly.
+        self.do_request(index_host, mode, 'query', 'Vector (Query only)',
+                    extra_args=["--pinecone-throughput-per-user=0"])


### PR DESCRIPTION
This option specifies how many requests per second each User instance should issue. Fractional values are permitted - e.g. a value of 0.1
will issue one request per user every 10 seconds.

Default value is 0 meaning 'unlimited', hence out-of-the-box behaviour is unchanged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
