### PR TITLE
Adjust Type column to align 'Pinecone gRPC' correctly

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -11,6 +11,7 @@ from locust import FastHttpUser, User, constant_throughput, events, tag, task
 from locust.env import Environment
 from locust.exception import StopUser
 from locust.runners import Runner, WorkerRunner
+import locust.stats
 from locust.user.task import DefaultTaskSet, TaskSet
 import logging
 import numpy as np
@@ -375,11 +376,15 @@ class PineconeSdk(User):
         self.host = environment.host
 
         if use_grpc:
-            self.request_type="Pine gRPC"
+            self.request_type="Pinecone gRPC"
             self.pinecone = PineconeGRPC(apikey)
         else:
-            self.request_type="Pine"
+            self.request_type="Pinecone"
             self.pinecone = Pinecone(apikey)
+        # Ensure stats 'Type' column is wide enough for our chosen mode so
+        # tables render correctly aligned (by default is only 8 chars wide).
+        locust.stats.STATS_TYPE_WIDTH = len(self.request_type) + 1
+
         self.index = self.pinecone.Index(host=self.host)
 
     def query(self, name: str, q_vector: list, top_k: int, q_filter=None, namespace=None):


### PR DESCRIPTION
## Problem

The default width of the stats 'Type' column is 8 chars. That is too
small to fit the 'Pine gRPC' name without the columns becoming
unaligned:

    Type     Name                               # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
    --------|---------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
    Pine gRPC  Fetch                                   1     0(0.00%) |    185     185     185    185 |    0.23        0.00
    Pine gRPC  Vector (Query only)                     3     0(0.00%) |    203     199     206    200 |    0.68        0.00
    --------|---------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
	     Aggregated                             16     0(0.00%) |    227     182     782    190 |    3.64        0.00

## Solution

Fix by expanding the size of the column to be based on the length of
the request type, and expanding 'Pine' -> 'Pinecone' to be more
explicit (now it fits).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
