### PR TITLE
Add --pinecone-recall option to report Recall

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -25,6 +25,26 @@ class Dataset:
             batch = df.iloc[i: i + batch_size]
             yield batch
 
+    @staticmethod
+    def recall(actual_matches: list, expected_matches: list):
+        # Recall@K : how many relevant items were returned against how many
+        # relevant items exist in the entire dataset. Defined as:
+        #     truePositives / (truePositives + falseNegatives)
+        #
+        # To allow us to calculate Recall when the count of actual_matches from
+        # the query differs from expected_matches (e.g. when Query is
+        # executed with a top_k different to what the Dataset was built with),
+        # limit denominator to the minimum of the expected & actual.
+        # (This allows use to use a Dataset with say 100 exact nearest
+        # neighbours and still test the quality of results when querying at
+        # top_k==10 as-if only the 10 exact nearest neighbours had been
+        # provided).
+        relevent_size = min(len(actual_matches), len(expected_matches))
+        expected_matches = expected_matches[:relevent_size]
+        true_positives = len(set(expected_matches).intersection(set(actual_matches)))
+        recall = true_positives / relevent_size
+        return recall
+
     def __init__(self, name: str = "", cache_dir: str = ""):
         self.name = name
         self.cache = pathlib.Path(cache_dir)

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -135,6 +135,25 @@ class TestPinecone(TestPineconeBase):
                                     "--pinecone-populate-index", "always",
                                     "--pinecone-dataset-ignore-queries"])
 
+    def test_recall(self, index_host):
+        # Simple smoke-test for --pinecone-recall; check it is accepted
+        # and no errors occur.
+        test_dataset = "ANN_MNIST_d784_euclidean"
+        self.do_request(index_host, "sdk", 'query', 'Vector (Query only)',
+                        extra_args=["--pinecone-dataset", test_dataset,
+                                    "--pinecone-dataset-limit", "10",
+                                    "--pinecone-recall"])
+
+    def test_recall_requires_nearest_neighbours(self, index_host):
+        # --pinecone-recall is incompatible with a dataset without
+        # nearest-neighbour information in the query set - e.g. when not
+        # specifying a dataset.
+        (proc, _, stderr) = spawn_locust(host=index_host,
+                                         mode="sdk",
+                                         timeout=10,
+                                         extra_args=["--tags", "query", "--pinecone-recall"])
+        assert "cannot calculate Recall" in stderr
+        assert proc.returncode == 1
 
 @pytest.mark.parametrize("mode", ["rest", "sdk", "sdk+grpc"])
 class TestPineconeModes(TestPineconeBase):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -20,3 +20,30 @@ class TestDataset:
 
         dataset.load(limit=limit, load_queries=False)
         assert len(dataset.documents) == limit
+
+    def test_recall_equal(self):
+        # Test recall() for equal length actual and expected lists.
+        assert Dataset.recall(["1"], ["1"]) == 1.0
+        assert Dataset.recall(["0"], ["1"]) == 0
+        assert Dataset.recall(["1", "3"], ["1", "2"]) == 0.5
+        assert Dataset.recall(["3", "1"], ["1", "2"]) == 0.5
+        assert Dataset.recall(["1", "2"], ["2", "1"]) == 1
+        assert Dataset.recall(["2", "3", "4", "5"], ["1", "2", "3", "4"]) == 0.75
+
+    def test_recall_actual_fewer_expected(self):
+        # Test recall() when actual matches is fewer than expected - i.e.
+        # query ran with lower top_k. In this situation recall() should
+        # only consider the k nearest expected_matches.
+        assert Dataset.recall(["1"], ["1", "2"]) == 1.0
+        assert Dataset.recall(["2"], ["1", "2"]) == 0
+        assert Dataset.recall(["1"], ["1", "2", "3"]) == 1.0
+        assert Dataset.recall(["1", "2"], ["1", "2", "3"]) == 1.0
+
+    def test_recall_actual_more_expected(self):
+        # Test recall() when actual matches are more than expected - i.e.
+        # query ran with a higher top_k. In this situation we should still
+        # compare against the full expected_matches.
+        assert Dataset.recall(["1", "2"], ["1"]) == 1.0
+        assert Dataset.recall(["1", "2"], ["2"]) == 1.0
+        assert Dataset.recall(["1", "3"], ["2"]) == 0
+        assert Dataset.recall(["1", "2", "3"], ["3"]) == 1


### PR DESCRIPTION
## Problem

For Vector Search using approximate nearest neighbour, how close the
returned query result(s) are to the exact nearest neighbour is an important
metric to measure.

## Solution

Add support for calculating Recall@N for queries, by making use of the
exact top_k present in the 'queries' set. Locust doesn't currently
have way to add additional metrics to the statistics reported, so this
patch reports them instead of latencies; expressing the Recall as a
value between 0 and 100 (locust doens't support fractional latency
values).

Example output:

    Response time percentiles (approximated)
    Type     Name                             50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
    --------|---------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
    PC gRPC  Vector (Query only)               98     99     99     99     99    100    100    100    100    100    100  10855
    --------|---------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
	     Aggregated                        99    100    100    100    100    100    100    100    100    100    100  21827

(Yes, the title is misleading, but it is not possible to customise
this in Locust).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

New integration test to cover new option.
