### PR TITLE
Skip loading documents if not needed

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -11,14 +11,14 @@ class TestDataset:
     def test_limit(self):
         limit = 123
         name = "langchain-python-docs-text-embedding-ada-002"
-        dataset = Dataset(name)
+        dataset = Dataset(name, limit=limit)
         # Sanity check that the complete dataset size is greater than what
         # we are going to limit to.
         dataset_info = ([d for d in dataset.list() if d["name"] == name][0])
         assert dataset_info["documents"] > limit, \
             "Too few documents in dataset to be able to limit"
 
-        dataset.load(limit=limit, load_queries=False)
+        dataset.load_documents()
         assert len(dataset.documents) == limit
 
     def test_recall_equal(self):


### PR DESCRIPTION
## Problem

The dataset contains a 'documents' set - the actual vectors to index,
and optionally a 'queries' set - the vectors to use for querying.
Depending on how locust has been configured, we may need to load none,
one or both of these sets - they can be large and take time to load,
therefore we want to avoid doing any unnecessary work.

## Solution

Restructure how Dataset loading is done - split load() into
load_documents() and setup_queries(), which will read into memory the
Parquet files according to the following rules:

* We must load the 'documents' set if we need to populate the index,
  or if there is no explicit 'queries' set and hence we need to sample
  them from the documents set.

* We must load the 'query' set if it exists (and we haven't been
  instructed to skip loading it).  To simplify the inter-dependencies,
  we load each on-demand when needed.

## Type of Change

- [x] Performance improvement
