### PR TITLE
Disable destructive requests (delete) by default

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -167,6 +167,7 @@ class TestPinecone(TestPineconeBase):
         assert stats[0]["min_response_time"] == 0
         assert stats[0]["max_response_time"] == 0
 
+
 @pytest.mark.parametrize("mode", ["rest", "sdk", "sdk+grpc"])
 class TestPineconeModes(TestPineconeBase):
     def test_pinecone_query(self, index_host, mode):
@@ -185,7 +186,8 @@ class TestPineconeModes(TestPineconeBase):
         self.do_request(index_host, mode, 'fetch', 'Fetch')
 
     def test_pinecone_delete(self, index_host, mode):
-        self.do_request(index_host, mode, 'delete', 'Delete')
+        self.do_request(index_host, mode, 'delete', 'Delete',
+                        extra_args=["--pinecone-destructive-tasks"])
 
     def test_pinecone_limit_throughput(self, index_host, mode):
         self.do_request(index_host, mode, 'query', 'Vector (Query only)',


### PR DESCRIPTION
## Problem

Destructive request types (currently delete) are not normally
interesting to include in load-testing - for example deleteById()
returns as soon as the delete has been accepted but not necessarily
when the delete has been applied to the index, so the reported latency
is somewhat meaningless. Furthermore, if any docs are modified
(delete) then on a subsequent run the entire index needs repopulating.

## Solution

As such, remove delete() from the default set of tasks. If delete (or
any other future destuctive requests) is needed, then it can be
enabled via the new option --pinecone-destructive-tasks.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

